### PR TITLE
Add default case for switch statements

### DIFF
--- a/user-documentlibrary-client/src/main/java/it/valeriovaudi/documentlibrary/utility/JsonUtility.java
+++ b/user-documentlibrary-client/src/main/java/it/valeriovaudi/documentlibrary/utility/JsonUtility.java
@@ -42,7 +42,10 @@ public class JsonUtility {
                 case NULL:
                     result = "";
                     break;
-
+                //missing default case
+                default:
+                    // add default case
+                    break;
             }
         }
         return result;


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html